### PR TITLE
Add function to remove guild commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ CLI tool to unregister all slash commands for a discord bot
 
 ## Usage
 
-`dsc-commands-remover -t YOUR_DISCORD_BOT_TOKEN -a APPLICATION_ID`
+`dsc-commands-remover -t YOUR_DISCORD_BOT_TOKEN -a APPLICATION_ID` global commands only
+
+`dsc-commands-remover -t YOUR_DISCORD_BOT_TOKEN -a APPLICATION_ID -g GUILD_ID` guild commands only
 
 `dsc-commands-remover -t YOUR_DISCORD_BOT_TOKEN -a APPLICATION_ID -y` for auto confirm

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,11 @@ pub struct Cli {
     #[clap(short, long)]
     pub application_id: String,
 
-    /// Remove all commands without confirmation
+    /// Optional. Only removes guild commands. When omitted, only removes global commands.
+    #[clap(short, long)]
+    pub guild_id: Option<String>,
+
+    /// Remove commands without confirmation
     #[clap(short, long, action)]
     pub yes: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,13 @@ pub const EMPTY_JSON_ARRAY: &serde_json::Value = &serde_json::json!([]);
 pub async fn remove_commands(application_id: &str, bot_token: &str, guild_id: &Option<String>) -> Result<(), reqwest::Error> {
     let url;
 
-    if guild_id.is_some() {
+    if guild_id.is_some() { // Only remove persistent commands for this guild
         url = format!(
             "https://discord.com/api/v10/applications/{}/guilds/{}/commands",
             application_id,
             guild_id.as_ref().unwrap(),
         );
-    }else{
+    }else{ // Only remove global commands
         url = format!(
             "https://discord.com/api/v10/applications/{}/commands",
             application_id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,27 @@ use reqwest::{header::AUTHORIZATION, Client};
 pub const EMPTY_JSON_ARRAY: &serde_json::Value = &serde_json::json!([]);
 
 /// Pushes `[]` as commands to Discord's API route
-pub async fn remove_commands(application_id: &str, bot_token: &str) -> Result<(), reqwest::Error> {
-    let client = Client::new();
+pub async fn remove_commands(application_id: &str, bot_token: &str, guild_id: &Option<String>) -> Result<(), reqwest::Error> {
+    let url;
 
-    let url = format!(
-        "https://discord.com/api/v10/applications/{}/commands",
-        application_id
-    );
+    if guild_id.is_some() {
+        url = format!(
+            "https://discord.com/api/v10/applications/{}/guilds/{}/commands",
+            application_id,
+            guild_id.as_ref().unwrap(),
+        );
+    }else{
+        url = format!(
+            "https://discord.com/api/v10/applications/{}/commands",
+            application_id
+        );
+    }
+
+    call_command_api(&url, bot_token).await
+}
+
+pub async fn call_command_api(url: &String, bot_token: &str) -> Result<(), reqwest::Error> {
+    let client = Client::new();
 
     let res = client
         .put(url)
@@ -20,6 +34,5 @@ pub async fn remove_commands(application_id: &str, bot_token: &str) -> Result<()
         .await?;
 
     res.error_for_status()?;
-
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,14 @@ pub const EMPTY_JSON_ARRAY: &serde_json::Value = &serde_json::json!([]);
 pub async fn remove_commands(application_id: &str, bot_token: &str, guild_id: &Option<String>) -> Result<(), reqwest::Error> {
     let url;
 
-    if guild_id.is_some() { // Only remove persistent commands for this guild
-        url = format!(
-            "https://discord.com/api/v10/applications/{}/guilds/{}/commands",
-            application_id,
-            guild_id.as_ref().unwrap(),
-        );
-    }else{ // Only remove global commands
-        url = format!(
-            "https://discord.com/api/v10/applications/{}/commands",
-            application_id
-        );
+    match guild_id {
+        Some(guild_id) => { // Only remove persistent commands for this guild
+            url = format!("https://discord.com/api/v10/applications/{}/guilds/{}/commands",
+                          application_id, guild_id, );
+        }
+        None => { // Only remove global commands
+            url = format!("https://discord.com/api/v10/applications/{}/commands", application_id);
+        }
     }
 
     call_command_api(&url, bot_token).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,18 +4,27 @@ use reqwest::{header::AUTHORIZATION, Client};
 pub const EMPTY_JSON_ARRAY: &serde_json::Value = &serde_json::json!([]);
 
 /// Pushes `[]` as commands to Discord's API route
-pub async fn remove_commands(application_id: &str, bot_token: &str, guild_id: &Option<String>) -> Result<(), reqwest::Error> {
-    let url;
-
-    match guild_id {
-        Some(guild_id) => { // Only remove persistent commands for this guild
-            url = format!("https://discord.com/api/v10/applications/{}/guilds/{}/commands",
-                          application_id, guild_id, );
+pub async fn remove_commands(
+    application_id: &str,
+    bot_token: &str,
+    guild_id: &Option<String>,
+) -> Result<(), reqwest::Error> {
+    let url = match guild_id {
+        Some(guild_id) => {
+            // Only remove persistent commands for this guild
+            format!(
+                "https://discord.com/api/v10/applications/{}/guilds/{}/commands",
+                application_id, guild_id,
+            )
         }
-        None => { // Only remove global commands
-            url = format!("https://discord.com/api/v10/applications/{}/commands", application_id);
+        None => {
+            // Only remove global commands
+            format!(
+                "https://discord.com/api/v10/applications/{}/commands",
+                application_id
+            )
         }
-    }
+    };
 
     call_command_api(&url, bot_token).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,18 +11,12 @@ async fn main() {
     let cli = Cli::parse();
     let mut cmd = Cli::command();
 
-    let prompt;
-    match cli.guild_id {
-        Some(_) => {prompt = "Do you want to remove all of your guild commands?";}
-        None => {prompt = "Do you want to remove all of your global commands?";}
-    }
+    let prompt = match cli.guild_id {
+        Some(_) => "Do you want to remove all of your guild commands?",
+        None => "Do you want to remove all of your global commands?",
+    };
 
-    if !cli.yes
-        && !Confirm::new()
-            .with_prompt(prompt)
-            .interact()
-            .unwrap()
-    {
+    if !cli.yes && !Confirm::new().with_prompt(prompt).interact().unwrap() {
         process::exit(1);
     }
 
@@ -30,8 +24,10 @@ async fn main() {
         cmd.error(ErrorKind::InvalidValue, err).exit();
     }
 
-    match cli.guild_id {
-        Some(_) => {println!("Removed guild commands successfully!");}
-        None => {println!("Removed global commands successfully!");}
-    }
+    let success_message = match cli.guild_id {
+        Some(_) => "Removed guild commands successfully!",
+        None => "Removed global commands successfully!",
+    };
+
+    println!("{}", success_message);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,18 +11,30 @@ async fn main() {
     let cli = Cli::parse();
     let mut cmd = Cli::command();
 
+    let prompt;
+    if cli.guild_id.is_some(){
+        prompt = "Do you want to remove all of your guild commands?";
+    }else{
+        prompt = "Do you want to remove all of your global commands?";
+    }
+
     if !cli.yes
         && !Confirm::new()
-            .with_prompt("Do you want to remove all of your commands?")
+            .with_prompt(prompt)
             .interact()
             .unwrap()
     {
         process::exit(1);
     }
 
-    if let Err(err) = remove_commands(&cli.application_id, &cli.bot_token).await {
+    if let Err(err) = remove_commands(&cli.application_id, &cli.bot_token, &cli.guild_id).await {
         cmd.error(ErrorKind::InvalidValue, err).exit();
     }
 
-    println!("Removed commands successfully!");
+    if cli.guild_id.is_some(){
+        println!("Removed guild commands successfully!");
+    }else{
+        println!("Removed global commands successfully!");
+    }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,9 @@ async fn main() {
     let mut cmd = Cli::command();
 
     let prompt;
-    if cli.guild_id.is_some(){
-        prompt = "Do you want to remove all of your guild commands?";
-    }else{
-        prompt = "Do you want to remove all of your global commands?";
+    match cli.guild_id {
+        Some(_) => {prompt = "Do you want to remove all of your guild commands?";}
+        None => {prompt = "Do you want to remove all of your global commands?";}
     }
 
     if !cli.yes
@@ -31,10 +30,8 @@ async fn main() {
         cmd.error(ErrorKind::InvalidValue, err).exit();
     }
 
-    if cli.guild_id.is_some(){
-        println!("Removed guild commands successfully!");
-    }else{
-        println!("Removed global commands successfully!");
+    match cli.guild_id {
+        Some(_) => {println!("Removed guild commands successfully!");}
+        None => {println!("Removed global commands successfully!");}
     }
-
 }


### PR DESCRIPTION
Added -g that lets you remove all (persistent) guild commands from a specific discord server by providing its guild ID without touching global commands. When this new parameter is left out, the application behaves as it did before.